### PR TITLE
refactor: 💡 Add options to the "call" middleware

### DIFF
--- a/packages/rudy/src/middleware/call/utils/shouldCall.js
+++ b/packages/rudy/src/middleware/call/utils/shouldCall.js
@@ -1,16 +1,14 @@
 // @flow
-import type { LocationState } from '../../../flow-types'
 import { isServer } from '@respond-framework/utils'
+import type { LocationState } from '../../../flow-types'
 import { isHydrate } from '../../../utils'
 
-export default (name, route, req) => {
+export default (name, route, req, { runOnServer, runOnHydrate }) => {
   if (!route[name] && !req.options[name]) return false
 
-  // skip callbacks (beforeEnter, thunk, etc) called on server, which produced initialState
-  if (isHydrate(req) && !/onEnter|onError/.test(name)) return false
+  if (isHydrate(req) && !runOnHydrate) return false
 
-  // dont allow these client-centric callbacks on the server
-  if (isServer() && /onEnter|Leave/.test(name)) return false
+  if (isServer() && !runOnServer) return false
 
   return allowBoth
 }

--- a/packages/rudy/src/middleware/pathlessRoute.js
+++ b/packages/rudy/src/middleware/pathlessRoute.js
@@ -4,7 +4,9 @@ export default (...names) => (api) => {
   names[0] = names[0] || 'thunk'
   names[1] = names[1] || 'onComplete'
 
-  const middlewares = names.map((name) => call(name, { skipOpts: true }))
+  const middlewares = names.map((name) =>
+    call(name, { runOnServer: true, skipOpts: true }),
+  )
 
   const pipeline = api.options.compose(
     middlewares,


### PR DESCRIPTION
"call" now needs the new options "runOnServer", "runOnHydrate" to be
passed explicitly, rather than using hard-coded logic to determine where
to run.
"runOnClientRender" has not been added since there's currently no
use-case for skipping client render.

This aims to clarify when each callback runs.