### PR TITLE
feat(boilerplate): Allow code splitting on the server

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "prettify:root": "prettier '**/*' --write",
     "prettify": "yarn run prettify:root && yarn run lerna run prettify",
     "vulnerabilities": "yarn run snyk test && yarn run lerna run vulnerabilities",
-    "check": "yarn run is-pretty && yarn run lint && yarn run build && yarn run test -- -- -w 1 && yarn run vulnerabilities"
+    "check": "yarn run is-pretty && yarn run lint && yarn run build && yarn run test -- -- -w 1"
   },
   "devDependencies": {
     "@babel/cli": "^7.1.2",

--- a/packages/boilerplate/babel.config.js
+++ b/packages/boilerplate/babel.config.js
@@ -8,6 +8,7 @@ module.exports = (api) => {
       webpack && 'react-hot-loader/babel',
       webpack && '@babel/plugin-syntax-dynamic-import',
       webpack && 'babel-plugin-universal-import',
+      !webpack && 'babel-plugin-dynamic-import-node',
     ].filter(Boolean),
   }
 }

--- a/packages/boilerplate/package.json
+++ b/packages/boilerplate/package.json
@@ -38,6 +38,7 @@
     "webpack-flush-chunks": "^2.0.3"
   },
   "devDependencies": {
+    "babel-plugin-dynamic-import-node": "^2.2.0",
     "babel-plugin-universal-import": "^3.0.3",
     "extract-css-chunks-webpack-plugin": "^3.1.3"
   },

--- a/packages/boilerplate/server/webpack.config.babel.js
+++ b/packages/boilerplate/server/webpack.config.babel.js
@@ -129,10 +129,6 @@ export default (env) => {
     },
     plugins: [
       isClient && new ExtractCssChunks(),
-      isServer &&
-        new webpack.optimize.LimitChunkCountPlugin({
-          maxChunks: 1,
-        }),
       isClient && isDev && new webpack.HotModuleReplacementPlugin(),
       isClient && isProd && new StatsPlugin('stats.json'),
       isClient && isProd && new webpack.HashedModuleIdsPlugin(), // not needed for strategy to work (just good practice)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2074,6 +2074,13 @@ babel-messages@^6.23.0:
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-plugin-dynamic-import-node@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.2.0.tgz#c0adfb07d95f4a4495e9aaac6ec386c4d7c2524e"
+  integrity sha512-fP899ELUnTaBcIzmrW7nniyqqdYWrWuJUyPWHxFa/c7r7hS6KC8FscNfLlBNIoPSc55kYMGEEKjPjJGCLbE1qA==
+  dependencies:
+    object.assign "^4.1.0"
+
 babel-plugin-istanbul@^4.1.6:
   version "4.1.6"
   resolved "http://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz#36c59b2192efce81c5b378321b74175add1c9a45"


### PR DESCRIPTION
The babel plugin `babel-plugin-dynamic-import-node` converts `import(<module>)` into something like `Promise.resolve(require(<module>))`. So we can use that on the server side to have code splitting, instead of having only a single chunk.

### Benefits
- Much faster incremental compilation time (if you change code in a small chunk, only that chunk needs to be re emitted). For example, changing `Home.js` took almost 10x less time to recompile than before.
- Potentially better caching of production builds, e.g. less changed code to minify on releases. 

### Limitations:
- Synchronous splitting (like the `vendor` chunk on the client side) doesn't work. That would require support in `webpack-hot-server-middleware` and `serveProd.js`. Both would have to require JS assets from multiple chunks for the chosen entry point (as per the webpack stats object) instead of assuming that there is only one.