### PR TITLE
fix: handle undefined prevroute during createStore/firstRoute

### DIFF
--- a/packages/rudy/src/middleware/call/index.js
+++ b/packages/rudy/src/middleware/call/index.js
@@ -21,6 +21,7 @@ export default (name, config = {}) => (api) => {
 
   return (req, next = noOp) => {
     const route = prev ? req.prevRoute : req.route
+    if (!route) return next()
 
     const isCached = cache && api.cache.isCached(name, route, req)
     if (isCached) return next()


### PR DESCRIPTION
Inside createStore, during execution of firstRoute(), req.prevRoute is undefined, so when the middleware chain gets to call("beforeLeave", { prev=true }), route becomes undefined, and it crashes with "no beforeLeave on undefined".
I've been using rudy for over a month without running into this, so there is probably another issue in my code or build process, but this change made it work for me.