### PR TITLE
chore(build): fix resolution of react package in boilerplate

### DIFF
--- a/packages/boilerplate/server/webpack.config.babel.js
+++ b/packages/boilerplate/server/webpack.config.babel.js
@@ -87,8 +87,8 @@ export default (env) => {
     resolve: {
       symlinks: false,
       extensions: isServer
-        ? ['.server.js', '.js', '.css']
-        : ['.browser.js', '.js', '.css'],
+        ? ['.server.js', '.js', '.jsx', '.css']
+        : ['.browser.js', '.js', '.jsx', '.css'],
       mainFields: [
         'rudy-src-main',
         isClient && 'browser',

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -4,7 +4,7 @@
   "description": "React component to create links which dispatch rudy routing actions",
   "main": "cjs/index.js",
   "module": "es/index.js",
-  "rudy-src-main": "src/index.jsx",
+  "rudy-src-main": "src/index.js",
   "repository": "https://github.com/respond-framework/rudy/tree/master/packages/react",
   "author": "James Gilmore",
   "license": "MIT",


### PR DESCRIPTION
It was not working without a fresh build as a result of these errors, as seen in https://github.com/respond-framework/rudy/pull/42