### PR TITLE
fix(history): delete console.log from BrowserHistory

### DIFF
--- a/packages/rudy/src/history/BrowserHistory.js
+++ b/packages/rudy/src/history/BrowserHistory.js
@@ -218,7 +218,6 @@ export default class BrowserHistory extends History {
       const url =
         typeof actOrUrl === 'string' ? actOrUrl : actOrUrl.location.url
       const ready = () => {
-        console.log('ready', url, locationToUrl(window.location))
         return url === locationToUrl(window.location)
       }
       return tryChange(ready, resolve, name, this) // TODO: is the this supposed to be there, its one extra param over
@@ -243,7 +242,6 @@ const rapidChangeWorkaround = (ready, complete, name) => {
   tries++
 
   if (!ready() && tries < maxTries) {
-    console.log('tries', tries + 1, name)
     setTimeout(() => rapidChangeWorkaround(ready, complete, name), 9)
   } else {
     if (process.env.NODE_ENV === 'test' && !ready()) {


### PR DESCRIPTION
I deleted console.log from BrowserHistory

see the issue for details on the typos fixed

fixes issue #46 