### PR TITLE
fix: update to released scroll-behavior API

### DIFF
--- a/packages/scroll-restorer/package.json
+++ b/packages/scroll-restorer/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@respond-framework/utils": "^0.1.1-test.1",
-    "scroll-behavior": "git+https://github.com/hedgepigdaniel/scroll-behavior.git#build/intermediate-scroll-2"
+    "scroll-behavior": "^0.9.11"
   },
   "peerDependencies": {
     "@respond-framework/types": "^0.1.1-test.1"

--- a/packages/scroll-restorer/package.json
+++ b/packages/scroll-restorer/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@respond-framework/utils": "^0.1.1-test.1",
-    "scroll-behavior": "git+https://github.com/hedgepigdaniel/scroll-behavior.git#build/intermediate-scroll"
+    "scroll-behavior": "git+https://github.com/hedgepigdaniel/scroll-behavior.git#build/intermediate-scroll-2"
   },
   "peerDependencies": {
     "@respond-framework/types": "^0.1.1-test.1"

--- a/packages/scroll-restorer/src/index.ts
+++ b/packages/scroll-restorer/src/index.ts
@@ -125,12 +125,14 @@ export class RudyScrollRestorer<Action extends FluxStandardRoutingAction>
       Object.keys(this.transitionHooks).forEach((hookIndex) => {
         this.transitionHooks[hookIndex]()
       })
+      this.behavior.startIgnoringScrollEvents()
       return next()
     }
   }
 
   restoreScroll: Middleware<Action> = () => {
     return (request, next) => {
+      this.behavior.stopIgnoringScrollEvents()
       this.behavior.updateScroll(null, request)
       return next()
     }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -25,6 +25,6 @@
     "prettify": "prettier --ignore-path=../../config/.prettierignore '**/*' --write"
   },
   "dependencies": {
-    "scroll-behavior": "git+https://github.com/hedgepigdaniel/scroll-behavior.git#build/intermediate-scroll"
+    "scroll-behavior": "git+https://github.com/hedgepigdaniel/scroll-behavior.git#build/intermediate-scroll-2"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -25,6 +25,6 @@
     "prettify": "prettier --ignore-path=../../config/.prettierignore '**/*' --write"
   },
   "dependencies": {
-    "scroll-behavior": "git+https://github.com/hedgepigdaniel/scroll-behavior.git#build/intermediate-scroll-2"
+    "scroll-behavior": "^0.9.11"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9356,9 +9356,9 @@ schema-utils@^2.1.0:
     ajv "^6.10.2"
     ajv-keywords "^3.4.1"
 
-"scroll-behavior@git+https://github.com/hedgepigdaniel/scroll-behavior.git#build/intermediate-scroll":
+"scroll-behavior@git+https://github.com/hedgepigdaniel/scroll-behavior.git#build/intermediate-scroll-2":
   version "0.9.10"
-  resolved "git+https://github.com/hedgepigdaniel/scroll-behavior.git#2980b68cc1658bda5923610421a12b325f28b056"
+  resolved "git+https://github.com/hedgepigdaniel/scroll-behavior.git#60757fbc5685557d93e00cd82612f035efb6876a"
   dependencies:
     dom-helpers "^3.4.0"
     invariant "^2.2.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9356,9 +9356,10 @@ schema-utils@^2.1.0:
     ajv "^6.10.2"
     ajv-keywords "^3.4.1"
 
-"scroll-behavior@git+https://github.com/hedgepigdaniel/scroll-behavior.git#build/intermediate-scroll-2":
-  version "0.9.10"
-  resolved "git+https://github.com/hedgepigdaniel/scroll-behavior.git#60757fbc5685557d93e00cd82612f035efb6876a"
+scroll-behavior@^0.9.11:
+  version "0.9.11"
+  resolved "https://registry.yarnpkg.com/scroll-behavior/-/scroll-behavior-0.9.11.tgz#f7b34380c038062bdcbd604c90e1d313220f7f3c"
+  integrity sha512-Eo32cg2uFiQwEiJXHHoTfXLybTlyA1O3ZOIiTz8EqRWie+ExL+7l8PcejhKT+5QmRtykXSlsTRVDC3BVB3S/bg==
   dependencies:
     dom-helpers "^3.4.0"
     invariant "^2.2.4"


### PR DESCRIPTION
Now that https://github.com/taion/scroll-behavior/pull/306 has been merged, this updates the dependency to the released version, including using the modified API that resulted from the review feedback.

Fixes https://github.com/respond-framework/rudy/issues/69