### PR TITLE
feat: restore fallback for broken sessionStorage

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,6 +7,7 @@
 **/.gitignore
 **/.flowconfig
 **/.npmignore
+**/.eslintcache
 
 # Ignored packages outside sub packages
 LICENSE

--- a/packages/rudy/src/history/BrowserHistory.js
+++ b/packages/rudy/src/history/BrowserHistory.js
@@ -16,7 +16,7 @@ import {
 import type { Action, Dispatch } from '../flow-types'
 
 // 1) HISTORY RESTORATION:
-// * FROM SESSION_STORAGE (WITH A FALLBACK TO OUR "HISTORY_STORAGE" SOLUTION)
+// * FROM SESSION_STORAGE
 
 // The `id` below is very important, as it's used to identify unique `sessionStorage` sessions lol.
 
@@ -30,9 +30,6 @@ import type { Action, Dispatch } from '../flow-types'
 
 // - then we restore the history using the id
 // - and for all subsequent history saving, we save to the correct storage with that `id`
-
-// NOTE: As far as the "HISTORY_STORAGE" fallback goes, please `sessionStorage.js`.
-// Essentially we save the entire sessionStorage in every entry of `window.history` :)
 
 // 2) POP HANDLING -- THE MOST IMPORTANT THING HERE:
 

--- a/packages/rudy/src/history/BrowserHistory.js
+++ b/packages/rudy/src/history/BrowserHistory.js
@@ -16,7 +16,7 @@ import {
 import type { Action, Dispatch } from '../flow-types'
 
 // 1) HISTORY RESTORATION:
-// * FROM SESSION_STORAGE
+// * FROM SESSION_STORAGE (WITH A FALLBACK TO OUR "HISTORY_STORAGE" SOLUTION)
 
 // The `id` below is very important, as it's used to identify unique `sessionStorage` sessions lol.
 
@@ -30,6 +30,9 @@ import type { Action, Dispatch } from '../flow-types'
 
 // - then we restore the history using the id
 // - and for all subsequent history saving, we save to the correct storage with that `id`
+
+// NOTE: As far as the "HISTORY_STORAGE" fallback goes, please `sessionStorage.js`.
+// Essentially we save the entire sessionStorage in every entry of `window.history` :)
 
 // 2) POP HANDLING -- THE MOST IMPORTANT THING HERE:
 

--- a/packages/scroll-restorer/src/index.ts
+++ b/packages/scroll-restorer/src/index.ts
@@ -13,6 +13,7 @@ import {
   ScrollRestorer,
   ScrollRestorerCreator,
 } from '@respond-framework/types'
+import { supportsSessionStorage } from '@respond-framework/utils'
 
 export { ScrollPosition } from 'scroll-behavior'
 
@@ -57,6 +58,9 @@ export class RudyScrollRestorer<Action extends FluxStandardRoutingAction>
     key: string | null,
     value: ScrollPosition,
   ): void => {
+    if (!supportsSessionStorage()) {
+      return
+    }
     window.sessionStorage.setItem(
       this.makeStorageKey(entry, key),
       JSON.stringify(value),
@@ -67,6 +71,9 @@ export class RudyScrollRestorer<Action extends FluxStandardRoutingAction>
     entry: LocationEntry<Action>,
     key: string | null,
   ): ScrollPosition | null => {
+    if (!supportsSessionStorage()) {
+      return null
+    }
     const savedItem = window.sessionStorage.getItem(
       this.makeStorageKey(entry, key),
     )

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,2 +1,3 @@
 export { default as isServer } from './isServer'
 export { default as createSelector } from './createSelector'
+export { default as supportsSessionStorage } from './supportsSessionStorage'

--- a/packages/utils/src/supportsSessionStorage.ts
+++ b/packages/utils/src/supportsSessionStorage.ts
@@ -1,0 +1,27 @@
+/* eslint-env browser */
+
+let _supportsSessionStorage: boolean
+
+export default (): boolean => {
+  if (_supportsSessionStorage !== undefined) {
+    return _supportsSessionStorage
+  }
+  try {
+    window.sessionStorage.setItem('rudytestitem', 'testvalue')
+    if (window.sessionStorage.getItem('rudytestitem') === 'testvalue') {
+      window.sessionStorage.removeItem('rudytestitem')
+      _supportsSessionStorage = true
+    } else {
+      _supportsSessionStorage = false
+    }
+  } catch {
+    _supportsSessionStorage = false
+  }
+  if (!_supportsSessionStorage) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      '[rudy]: WARNING: This browser does not support sessionStorage!',
+    )
+  }
+  return _supportsSessionStorage
+}


### PR DESCRIPTION
The subset of the history of browser history stack entries within the current session is mirrored in sessionStorage so that it can be restored into Redux on page reload or on navigation from external history stack entries (using the borwser back/forward buttons, reload button, unfreezing, etc). There used to be a fallback for browsers where sessionStorage is not supported which instead stored the entries inside the current history state. This fallback was removed as part of https://github.com/respond-framework/rudy/pull/61. However, although all modern browsers officially support sessionStorage, there are various circumstances in which it fails to work:
- if the user fills the entire quota (very unlikely that Rudy itself would do this, but other user code might)
- in private browsing mode on iOS Safari
- if all cookies are disabled in Chrome (and possibly also in some modified versions of chrome for android)

This change restores that fallback. It comes with the same caveats that were there before:
- since only the current history index is accessible, only the current and previous stack entries can be seen. This means that when returning to a stack entry in the middle of r the Rudy stack, the redux mirror of the stack entries will only include current and past entries, not future ones.
- as a consequence, route callbacks that occur before a transition to a route will not work when navigating forward beyond the entries in the redux state.